### PR TITLE
Just Logic Fixes

### DIFF
--- a/worlds/dead_cells/rules.py
+++ b/worlds/dead_cells/rules.py
@@ -539,6 +539,8 @@ LOCATION_RULES = [
     
     ("Abyssal Trident", _has("Ram Rune")),
 
+
+
     # Cursed Biome drops
     (
         "Anathema", 
@@ -604,6 +606,19 @@ LOCATION_RULES = [
                 "Castle's Outskirts Enter",
                 "Dilapidated Arboretum Enter",
             ]
+        )
+    ),
+
+    (
+        "Acceptance",
+        _has_all(
+            "Vine Rune", 
+            "Ram Rune", 
+            "Insufferable Crypt Unlock", 
+            "Graveyard Unlock", 
+            "Spider Rune", 
+            "Teleportation Rune", 
+            "Forgotten Sepulcher Unlock",
         )
     ),
 

--- a/worlds/dead_cells/rules.py
+++ b/worlds/dead_cells/rules.py
@@ -661,6 +661,9 @@ LOCATION_RULES = [
     # Parting Gift Graveyard secret
     ("Parting Gift", _has("Ram Rune")),
 
+    # Parry Shield Stilt Village secret
+    ("Parry Shield", _has_all("Spider Rune", "Ram Rune")),
+
     # ── Boss Rush Items ──────────────────────────────────────────────────────
     ("Boss Knight Outfit", _boss_rush_trials_1_2()),
     ("Barbarian Boss Knight Outfit", _boss_rush_trials_3_4() and _bsc(3)),

--- a/worlds/dead_cells/rules.py
+++ b/worlds/dead_cells/rules.py
@@ -536,6 +536,9 @@ LOCATION_RULES = [
         lambda state: state.can_reach("SewerShort", "Region", world.player)
     )),
 
+    
+    ("Abyssal Trident", _has("Ram Rune")),
+
     # Cursed Biome drops
     (
         "Anathema", 


### PR DESCRIPTION
Abyssal Trident now logically requires Ram Rune
Acceptance now logically requires the entirety of its associated route access
Parry Shield now logically requires Ram Rune and Spider Rune